### PR TITLE
Fix TypeError for Offset-naive and Offset-aware Datetimes in Pending Order Processing

### DIFF
--- a/app.py
+++ b/app.py
@@ -1918,6 +1918,15 @@ def add_pending_order_to_db(rec: Dict[str, Any]):
         # Leave as-is on parse failure
         pass
 
+    # Also update the in-memory record so callers referencing the same dict see normalized values
+    try:
+        if place_time_val:
+            rec['place_time'] = place_time_val
+        if expiry_val:
+            rec['expiry_time'] = expiry_val
+    except Exception:
+        pass
+
     values = (
         rec.get('id'), rec.get('order_id'), rec.get('symbol'), rec.get('side'),
         rec.get('qty'), rec.get('limit_price'), stop_val, take_val,


### PR DESCRIPTION
This PR addresses a TypeError that occurred when processing pending orders due to a comparison between offset-naive and offset-aware datetimes. The changes made in `app.py` ensure that the `place_time` and `expiry_time` fields are updated properly in the in-memory record when valid values are present. By doing this, we prevent potential errors when the function references these datetime values, enhancing the stability of the order processing flow.

---

> This pull request was co-created with Cosine Genie

Original Task: [Bot-4.0/6ewmk3hqese0](https://cosine.sh/p0drixu2k2bx/Bot-4.0/task/6ewmk3hqese0)
Author: Janith Manodaya
